### PR TITLE
Add reminder feature / voice command reminder

### DIFF
--- a/reminders.html
+++ b/reminders.html
@@ -46,6 +46,19 @@
       font-weight: 500;
     }
 
+    
+    /* Mic listening animation */
+    #voiceAdd.listening {
+      animation: pulse 1s infinite;
+      box-shadow: 0 0 15px rgba(110,231,183,0.5), 0 0 30px rgba(192,132,252,0.5);
+    }
+    @keyframes pulse {
+      0% { transform: scale(1); }
+      50% { transform: scale(1.2); }
+      100% { transform: scale(1); }
+    }
+
+
     /* ====== Heading Typewriter + Gradient Glow ====== */
     h1.display, h2 {
       display: inline-block;
@@ -313,6 +326,69 @@
     window.addEventListener('DOMContentLoaded', () => {
       // Initialize Step 2 persistence feature
       ReminderStorage.init('reminderForm', 'list');
+
+       // ====== Voice Add Reminder ======
+      const voiceBtn = document.getElementById('voiceAdd');
+      const form = document.getElementById('reminderForm');
+      const toast = document.getElementById('toast');
+
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognition) return; // unsupported
+
+      const recognition = new SpeechRecognition();
+      recognition.continuous = false;
+      recognition.interimResults = false;
+      recognition.lang = 'en-US';
+
+      function showToast(msg) {
+        toast.textContent = msg;
+        toast.classList.add('show');
+        setTimeout(() => toast.classList.remove('show'), 3000);
+      }
+
+      function speak(msg) {
+        if (!window.speechSynthesis) return;
+        const u = new SpeechSynthesisUtterance(msg);
+        window.speechSynthesis.speak(u);
+      }
+
+      voiceBtn.addEventListener('click', () => {
+        recognition.start();
+        voiceBtn.classList.add('listening');
+        showToast("🎤 Listening...");
+      });
+
+      recognition.addEventListener('result', e => {
+        const transcript = e.results[0][0].transcript.toLowerCase().trim();
+        voiceBtn.classList.remove('listening');
+
+        // Parse "remind me to <title> at <HH:MM>"
+        const match = transcript.match(/remind me to (.+?) at (\d{1,2}(:\d{2})?\s?(am|pm)?)/);
+        if (match) {
+          let [_, title, time] = match;
+          if (time.match(/am|pm/)) {
+            const t = new Date(`01/01/2000 ${time}`);
+            time = t.getHours().toString().padStart(2,'0') + ':' + t.getMinutes().toString().padStart(2,'0');
+          }
+          form.title.value = title.charAt(0).toUpperCase() + title.slice(1);
+          form.time.value = time;
+          form.type.value = 'other';
+          form.repeat.value = 'once';
+          form.notes.value = '';
+          form.enabled.checked = true;
+
+          // Submit form programmatically
+          form.dispatchEvent(new Event('submit', { bubbles:true, cancelable:true }));
+          showToast(`✅ Reminder added: "${title}" at ${time}`);
+          speak(`Reminder added: ${title} at ${time}`);
+        } else {
+          showToast("❌ Command not recognized. Say: 'Remind me to ... at ...'");
+          speak("Command not recognized");
+        }
+      });
+
+      recognition.addEventListener('end', () => voiceBtn.classList.remove('listening'));
+    
     });
   </script>
 </body>


### PR DESCRIPTION
# 🛠️ Pull Request Template

## 📌 Related Issue
Fixes #93

## ✨ Description
This PR adds a Reminders feature to the CareEase app. Users can now:

Create, edit, and delete reminders for medicines, vitals, appointments, and other tasks.

View active and missed reminders.

Trigger alerts at the set times, including voice notifications using the browser's Speech API.

Export and import reminders as JSON.
## 🧪 Type of Change
Select all that apply:
- [ ] 🐞 Bug fix  
- [ x] ✨ New feature  
- [ ] ♻️ Code refactor  
- [ ] 📝 Documentation update  
- [ x] 💄 UI/UX improvement  
- [ ] 🔧 Chore or maintenance  

## 🧩 How Has This Been Tested?
Describe the tests you ran to verify your changes.  
Manually added multiple reminders with different types and times.

Verified that alerts trigger at the correct time.

Tested the voice alert functionality across Chrome and Firefox.

Tested export/import feature to ensure reminders persist correctly.

Checked UI responsiveness and accessibility.

Steps to reproduce:

Go to the Reminders page.

Click + Add reminder, fill the form, and save.

Wait for the scheduled time to verify alert (or use the Test alert button).

Export and re-import reminders to test JSON persistence.

## 📸 Screenshots or Recordings(if applicable)





## ✅ Checklist
- [ x] My code follows the project’s style guidelines  
- [ x] I have performed a self-review of my code  
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings or errors    
- [ x] Linked the related issue number properly  

---

💚 Thank you for contributing to **CareEase**!
